### PR TITLE
Add missing translation of rfc4960

### DIFF
--- a/html/rfc4960.html
+++ b/html/rfc4960.html
@@ -6869,7 +6869,7 @@ Notes:
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-3) If the T1-cookie timer expires, the endpoint MUST retransmit COOKIE ECHO and restart the T1-cookie timer without changing state. This MUST be repeated up to &#39;Max.Init.Retransmits&#39; times. After that, the endpoint MUST abort the initialization process and report the error to the SCTP user.
+3）T1-cookieタイマーが期限切れになった場合、エンドポイントはCOOKIE ECHOを再送信し、状態を変更せずにT1-cookieタイマーを再起動する必要があります。 これは、「Max.Init.Retransmits」回まで繰り返す必要があります。 その後、エンドポイントは初期化プロセスを中止し、SCTPユーザーにエラーを報告する必要があります。
         </p>
       </div>
     </div>
@@ -7027,7 +7027,7 @@ A) &#34;A&#34; first sends an INIT chunk to &#34;Z&#34;. In the INIT, &#34;A&#34
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-A) &#34;A&#34; first sends an INIT chunk to &#34;Z&#34;. In the INIT, &#34;A&#34; must provide its Verification Tag (Tag_A) in the Initiate Tag field. Tag_A SHOULD be a random number in the range of 1 to 4294967295 (see Section 5.3.1 for Tag value selection). After sending the INIT, &#34;A&#34; starts the T1-init timer and enters the COOKIE-WAIT state.
+A）「A」は最初にINITチャンクを「Z」に送信します。 INITでは、「A」は「タグの開始」フィールドに検証タグ（Tag_A）を指定する必要があります。 Tag_Aは、1〜4294967295の範囲の乱数である必要があります（タグ値の選択については、セクション5.3.1を参照してください）。 INITを送信した後、「A」はT1-initタイマーを開始し、COOKIE-WAIT状態に入ります。 
         </p>
       </div>
     </div>
@@ -7063,7 +7063,7 @@ Note: After sending out INIT ACK with the State Cookie parameter, &#34;Z&#34; MU
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-6">
-Note: After sending out INIT ACK with the State Cookie parameter, &#34;Z&#34; MUST NOT allocate any resources or keep any states for the new association. Otherwise, &#34;Z&#34; will be vulnerable to resource attacks.
+注：StateCookieパラメーターを指定してINITACKを送信した後、「Z」はリソースを割り当てたり、新しい関連付けの状態を保持したりしてはなりません（MUSTNOT）。 そうしないと、「Z」はリソース攻撃に対して脆弱になります。
         </p>
       </div>
     </div>
@@ -7087,7 +7087,7 @@ Note: The COOKIE ECHO chunk can be bundled with any pending outbound DATA chunks
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-6">
-Note: The COOKIE ECHO chunk can be bundled with any pending outbound DATA chunks, but it MUST be the first chunk in the packet and until the COOKIE ACK is returned the sender MUST NOT send any other packets to the peer.
+注：COOKIE ECHOチャンクは、保留中のアウトバウンドDATAチャンクとバンドルできますが、パケットの最初のチャンクである必要があり、COOKIE ACKが返されるまで、送信者は他のパケットをピアに送信してはなりません。
         </p>
       </div>
     </div>
@@ -7171,7 +7171,7 @@ If an endpoint receives an INIT, INIT ACK, or COOKIE ECHO chunk but decides not 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-If an endpoint receives an INIT, INIT ACK, or COOKIE ECHO chunk but decides not to establish the new association due to missing mandatory parameters in the received INIT or INIT ACK, invalid parameter values, or lack of local resources, it SHOULD respond with an ABORT chunk. It SHOULD also specify the cause of abort, such as the type of the missing mandatory parameters, etc., by including the error cause parameters with the ABORT chunk. The Verification Tag field in the common header of the outbound SCTP packet containing the ABORT chunk MUST be set to the Initiate Tag value of the peer.
+エンドポイントがINIT、INIT ACK、またはCOOKIE ECHOチャンクを受信したが、受信したINITまたはINIT ACKに必須パラメーターがない、無効なパラメーター値、またはローカルリソースがないために新しい関連付けを確立しないことを決定した場合、エンドポイントは応答する必要があります。 ABORTチャンク。 また、ABORTチャンクにエラー原因パラメーターを含めることにより、欠落している必須パラメーターのタイプなど、中止の原因を指定する必要があります。 ABORTチャンクを含むアウトバウンドSCTPパケットの共通ヘッダーのVerificationTagフィールドは、ピアのInitiateTag値に設定する必要があります。
         </p>
       </div>
     </div>
@@ -7244,7 +7244,7 @@ In the INIT and INIT ACK chunks, the sender of the chunk MUST indicate the numbe
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-In the INIT and INIT ACK chunks, the sender of the chunk MUST indicate the number of outbound streams (OSs) it wishes to have in the association, as well as the maximum inbound streams (MISs) it will accept from the other endpoint.
+INITチャンクとINITACKチャンクでは、チャンクの送信者は、アソシエーションに含めるアウトバウンドストリーム（OS）の数と、他のエンドポイントから受け入れる最大インバウンドストリーム（MIS）を指定する必要があります。
         </p>
       </div>
     </div>
@@ -7268,7 +7268,7 @@ After the association is initialized, the valid outbound stream identifier range
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-After the association is initialized, the valid outbound stream identifier range for either endpoint shall be 0 to min(local OS, remote MIS)-1.
+アソシエーションが初期化された後、いずれかのエンドポイントの有効なアウトバウンドストリーム識別子の範囲は0〜min（ローカルOS、リモートMIS）-1でなければなりません。
         </p>
       </div>
     </div>
@@ -7449,7 +7449,7 @@ Note: The INIT ACK MUST be sent to the source address of the INIT.
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-Note: The INIT ACK MUST be sent to the source address of the INIT.
+注：INIT ACKは、INITの送信元アドレスに送信する必要があります。
         </p>
       </div>
     </div>
@@ -7716,7 +7716,7 @@ When an endpoint receives a COOKIE ECHO chunk from another endpoint with which i
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-3) Compare the port numbers and the Verification Tag contained within the COOKIE ECHO chunk to the actual port numbers and the Verification Tag within the SCTP common header of the received packet. If these values do not match, the packet MUST be silently discarded.
+3）COOKIE ECHOチャンクに含まれるポート番号と検証タグを、受信したパケットのSCTP共通ヘッダー内の実際のポート番号と検証タグと比較します。 これらの値が一致しない場合、パケットはサイレントに破棄されなければなりません（MUST）。
         </p>
       </div>
     </div>
@@ -8099,7 +8099,7 @@ COOKIE-ECHOED状態にあるエンドポイントの場合、アソシエーシ�
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-0">
-5.2.2. Unexpected INIT in States Other than CLOSED, COOKIE-ECHOED, COOKIE-WAIT, and SHUTDOWN-ACK-SENT
+5.2.2. CLOSED、COOKIE-ECHOED、COOKIE-WAIT、およびSHUTDOWN-ACK-SENT以外の状態での予期しないINIT
         </p>
       </div>
     </div>
@@ -8781,7 +8781,7 @@ During association establishment, the two peers exchange a list of addresses. In
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-3) All other addresses not covered by rules 1 and 2 are considered UNCONFIRMED and are subject to probing for verification.
+3）ルール1および2でカバーされていない他のすべてのアドレスは未確認と見なされ、検証のための調査の対象となります。
         </p>
       </div>
     </div>
@@ -9273,7 +9273,7 @@ Before an endpoint transmits a DATA chunk, if any received DATA chunks have not 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-Before an endpoint transmits a DATA chunk, if any received DATA chunks have not been acknowledged (e.g., due to delayed ack), the sender should create a SACK and bundle it with the outbound DATA chunk, as long as the size of the final SCTP packet does not exceed the current MTU. See Section 6.2.
+エンドポイントがDATAチャンクを送信する前に、受信したDATAチャンクが確認応答されていない場合（たとえば、遅延ACKのため）、送信者はSACKを作成し、最終的なSCTPのサイズである限り、送信DATAチャンクとバンドルする必要があります パケットは現在のMTUを超えません。 セクション6.2を参照してください。
         </p>
       </div>
     </div>
@@ -9394,7 +9394,7 @@ IMPLEMENTATION NOTE: The maximum delay for generating an acknowledgement may be 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-IMPLEMENTATION NOTE: The maximum delay for generating an acknowledgement may be configured by the SCTP administrator, either statically or dynamically, in order to meet the specific timing requirement of the protocol being carried.
+実装上の注意：確認応答を生成するための最大遅延は、実行されているプロトコルの特定のタイミング要件を満たすために、静的または動的にSCTP管理者が構成できます。
         </p>
       </div>
     </div>
@@ -9764,7 +9764,7 @@ D) Any time a SACK arrives, the endpoint performs the following:
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-D) Any time a SACK arrives, the endpoint performs the following:
+D）SACKが到着するたびに、エンドポイントは次のことを実行します。
         </p>
       </div>
     </div>
@@ -10167,7 +10167,7 @@ R3) Whenever a SACK is received that acknowledges the DATA chunk with the earlie
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-R3) Whenever a SACK is received that acknowledges the DATA chunk with the earliest outstanding TSN for that address, restart the T3-rtx timer for that address with its current RTO (if there is still outstanding data on that address).
+R3）そのアドレスの最も早い未処理のTSNでDATAチャンクを確認するSACKを受信するたびに、そのアドレスのT3-rtxタイマーを現在のRTOで再起動します（そのアドレスに未処理のデータがまだある場合）。
         </p>
       </div>
     </div>
@@ -10265,7 +10265,7 @@ E1) For the destination address for which the timer expires, adjust its ssthresh
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-E1) For the destination address for which the timer expires, adjust its ssthresh with rules defined in Section 7.2.3 and set the cwnd &lt;- MTU.
+E1）タイマーが時間切れになる宛先アドレスについては、セクション7.2.3で定義されたルールを使用してそのssthreshを調整し、cwnd &lt;-MTUを設定します。
         </p>
       </div>
     </div>
@@ -10483,7 +10483,7 @@ Some of the transport addresses of a multi-homed SCTP endpoint may become inacti
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-Some of the transport addresses of a multi-homed SCTP endpoint may become inactive due to either the occurrence of certain error conditions (see Section 8.2) or adjustments from the SCTP user.
+マルチホームSCTPエンドポイントの一部のトランスポートアドレスは、特定のエラー状態（セクション8.2を参照）の発生またはSCTPユーザーからの調整により、非アクティブになる場合があります。
         </p>
       </div>
     </div>
@@ -10495,7 +10495,7 @@ When there is outbound data to send and the primary path becomes inactive (e.g.,
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-When there is outbound data to send and the primary path becomes inactive (e.g., due to failures), or where the SCTP user explicitly requests to send data to an inactive destination transport address, before reporting an error to its ULP, the SCTP endpoint should try to send the data to an alternate active destination transport address if one exists.
+送信するアウトバウンドデータがあり、プライマリパスが非アクティブになった場合（障害など）、またはSCTPユーザーがULPにエラーを報告する前に、非アクティブな宛先トランスポートアドレスにデータを送信するように明示的に要求した場合、SCTPエンドポイントは 代替のアクティブな宛先トランスポートアドレス（存在する場合）にデータを送信してみてください。
         </p>
       </div>
     </div>
@@ -10593,7 +10593,7 @@ However, an SCTP endpoint can indicate that no ordered delivery is required for 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-However, an SCTP endpoint can indicate that no ordered delivery is required for a particular DATA chunk transmitted within the stream by setting the U flag of the DATA chunk to 1.
+ただし、SCTPエンドポイントは、DATAチャンクのUフラグを1に設定することにより、ストリーム内で送信される特定のDATAチャンクに順序付けられた配信が不要であることを示すことができます。
         </p>
       </div>
     </div>
@@ -10866,7 +10866,7 @@ After the packet is constructed (containing the SCTP common header and one or mo
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-3) put the resultant value into the checksum field in the common header, and leave the rest of the bits unchanged.
+3）結果の値を共通ヘッダーのチェックサムフィールドに入れ、残りのビットは変更しないでください。
         </p>
       </div>
     </div>
@@ -11156,7 +11156,7 @@ When bundling control chunks with DATA chunks, an endpoint MUST place control ch
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-When bundling control chunks with DATA chunks, an endpoint MUST place control chunks first in the outbound SCTP packet. The transmitter MUST transmit DATA chunks within an SCTP packet in increasing order of TSN.
+制御チャンクをDATAチャンクとバンドルする場合、エンドポイントは制御チャンクを最初にアウトバウンドSCTPパケットに配置する必要があります。 送信機は、TSNの昇順でSCTPパケット内のDATAチャンクを送信する必要があります。
         </p>
       </div>
     </div>
@@ -11241,7 +11241,7 @@ IMPLEMENTATION NOTE: As far as its specific performance requirements are met, an
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-IMPLEMENTATION NOTE: As far as its specific performance requirements are met, an implementation is always allowed to adopt a more conservative congestion control algorithm than the one defined below.
+実装上の注意：特定のパフォーマンス要件が満たされている限り、実装では、以下に定義するものよりも保守的な輻輳制御アルゴリズムを採用することが常に許可されます。
         </p>
       </div>
     </div>
@@ -11387,7 +11387,7 @@ Like TCP, an SCTP endpoint uses the following three control variables to regulat
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-Like TCP, an SCTP endpoint uses the following three control variables to regulate its transmission rate.
+TCPと同様に、SCTPエンドポイントは次の3つの制御変数を使用して伝送速度を調整します。
         </p>
       </div>
     </div>
@@ -11471,7 +11471,7 @@ SCTP also requires one additional control variable, partial_bytes_acked, which i
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-SCTP also requires one additional control variable, partial_bytes_acked, which is used during congestion avoidance phase to facilitate cwnd adjustment.
+SCTPには、1つの追加の制御変数partial_bytes_ackedも必要です。これは、輻輳回避フェーズ中にcwnd調整を容易にするために使用されます。
         </p>
       </div>
     </div>
@@ -11544,7 +11544,7 @@ o The initial value of ssthresh MAY be arbitrarily high (for example, implementa
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-o The initial value of ssthresh MAY be arbitrarily high (for example, implementations MAY use the size of the receiver advertised window).
+o ssthreshの初期値は、任意に高くすることができます（たとえば、実装では、レシーバーがアドバタイズしたウィンドウのサイズを使用できます）。
         </p>
       </div>
     </div>
@@ -11556,7 +11556,7 @@ o Whenever cwnd is greater than zero, the endpoint is allowed to have cwnd bytes
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-o Whenever cwnd is greater than zero, the endpoint is allowed to have cwnd bytes of data outstanding on that transport address.
+o cwndがゼロより大きい場合は常に、エンドポイントはそのトランスポートアドレスで未処理のデータのcwndバイトを持つことができます。
         </p>
       </div>
     </div>
@@ -11878,7 +11878,7 @@ TSNに対して3回目の連続したミス表示が受信された場合、デ�
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-4) Restart the T3-rtx timer only if the last SACK acknowledged the lowest outstanding TSN number sent to that address, or the endpoint is retransmitting the first outstanding DATA chunk sent to that address.
+4）最後のSACKがそのアドレスに送信された最小の未処理のTSN番号を確認した場合、またはエンドポイントがそのアドレスに送信された最初の未処理のDATAチャンクを再送信している場合にのみ、T3-rtxタイマーを再起動します。
         </p>
       </div>
     </div>
@@ -11963,7 +11963,7 @@ SCTPのcwndは、未解決のTSNの数を間接的に制限するため、輻輳
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-[RFC4821], [RFC1981], and [RFC1191] specify &#34;Packetization Layer Path MTU Discovery&#34;, whereby an endpoint maintains an estimate of the maximum transmission unit (MTU) along a given Internet path and refrains from sending packets along that path that exceed the MTU, other than occasional attempts to probe for a change in the Path MTU (PMTU). [RFC4821] is thorough in its discussion of the MTU discovery mechanism and strategies for determining the current end-to-end MTU setting as well as detecting changes in this value.
+[RFC4821]、[RFC1981]、および[RFC1191]は、「パケット化レイヤーパスMTUディスカバリー」を指定します。これにより、エンドポイントは、特定のインターネットパスに沿った最大伝送ユニット（MTU）の推定値を維持し、パケットの送信を控えます。 パスMTU（PMTU）の変更をプローブしようとする場合を除いて、MTUを超えるパスに沿って。 [RFC4821]は、現在のエンドツーエンドのMTU設定を決定し、この値の変化を検出するためのMTU検出メカニズムと戦略について徹底的に説明しています。
         </p>
       </div>
     </div>
@@ -12049,7 +12049,7 @@ An endpoint shall keep a counter on the total number of consecutive retransmissi
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-An endpoint shall keep a counter on the total number of consecutive retransmissions to its peer (this includes retransmissions to all the destination transport addresses of the peer if it is multi-homed), including unacknowledged HEARTBEAT chunks. If the value of this counter exceeds the limit indicated in the protocol parameter &#39;Association.Max.Retrans&#39;, the endpoint shall consider the peer endpoint unreachable and shall stop transmitting any more data to it (and thus the association enters the CLOSED state). In addition, the endpoint MAY report the failure to the upper layer and optionally report back all outstanding user data remaining in its outbound queue. The association is automatically closed when the peer endpoint becomes unreachable.
+エンドポイントは、未確認のHEARTBEATチャンクを含む、ピアへの連続した再送信の総数（マルチホームの場合、ピアのすべての宛先トランスポートアドレスへの再送信を含む）のカウンターを保持する必要があります。 このカウンターの値がプロトコルパラメーター＆＃39; Association.Max.Retrans＆＃39;に示されている制限を超えると、エンドポイントはピアエンドポイントに到達できないと見なし、それ以上のデータの送信を停止します（したがって、関連付けは次のようになります。 CLOSED状態）。 さらに、エンドポイントは障害を上位層に報告し、オプションでアウトバウンドキューに残っているすべての未処理のユーザーデータを報告してもよい[MAY]。 ピアエンドポイントが到達不能になると、アソシエーションは自動的に閉じられます。
         </p>
       </div>
     </div>
@@ -12098,7 +12098,7 @@ Each time the T3-rtx timer expires on any address, or when a HEARTBEAT sent to a
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-Each time the T3-rtx timer expires on any address, or when a HEARTBEAT sent to an idle address is not acknowledged within an RTO, the error counter of that destination address will be incremented. When the value in the error counter exceeds the protocol parameter &#39;Path.Max.Retrans&#39; of that destination address, the endpoint should mark the destination transport address as inactive, and a notification SHOULD be sent to the upper layer.
+いずれかのアドレスでT3-rtxタイマーが期限切れになるたび、またはアイドルアドレスに送信されたHEARTBEATがRTO内で確認応答されない場合、その宛先アドレスのエラーカウンターがインクリメントされます。 エラーカウンタの値がプロトコルパラメータ＆＃39; Path.Max.Retrans＆＃39;を超えた場合 その宛先アドレスのうち、エンドポイントは宛先トランスポートアドレスを非アクティブとしてマークする必要があり、通知を上位層に送信する必要があります。
         </p>
       </div>
     </div>
@@ -12267,7 +12267,7 @@ The sender of the HEARTBEAT chunk should include in the Heartbeat Information fi
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-The sender of the HEARTBEAT chunk should include in the Heartbeat Information field of the chunk the current time when the packet is sent out and the destination address to which the packet is sent.
+HEARTBEATチャンクの送信者は、パケットが送信される現在の時刻とパケットの送信先アドレスをチャンクのハートビート情報フィールドに含める必要があります。
         </p>
       </div>
     </div>
@@ -12448,7 +12448,7 @@ OOTBパケットの受信者は、以下を実行する必要があります。
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-5) If the packet contains a SHUTDOWN ACK chunk, the receiver should respond to the sender of the OOTB packet with a SHUTDOWN COMPLETE. When sending the SHUTDOWN COMPLETE, the receiver of the OOTB packet must fill in the Verification Tag field of the outbound packet with the Verification Tag received in the SHUTDOWN ACK and set the T bit in the Chunk Flags to indicate that the Verification Tag is reflected. Otherwise,
+5）パケットにSHUTDOWN ACKチャンクが含まれている場合、受信者はOOTBパケットの送信者にSHUTDOWNCOMPLETEで応答する必要があります。 SHUTDOWN COMPLETEを送信する場合、OOTBパケットの受信者は、SHUTDOWN ACKで受信した検証タグをアウトバウンドパケットの検証タグフィールドに入力し、チャンクフラグのTビットを設定して検証タグが反映されていることを示す必要があります。 さもないと、
         </p>
       </div>
     </div>
@@ -12873,7 +12873,7 @@ The rules in Section 6.3 MUST be followed to determine the proper timer value fo
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-The rules in Section 6.3 MUST be followed to determine the proper timer value for T2-shutdown. To indicate any gaps in TSN, the endpoint may also bundle a SACK with the SHUTDOWN chunk in the same SCTP packet.
+T2シャットダウンの適切なタイマー値を決定するには、セクション6.3のルールに従う必要があります。 TSNのギャップを示すために、エンドポイントは同じSCTPパケット内のSHUTDOWNチャンクとSACKをバンドルすることもできます。
         </p>
       </div>
     </div>
@@ -12957,7 +12957,7 @@ If there are still outstanding DATA chunks left, the SHUTDOWN receiver MUST cont
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-If there are still outstanding DATA chunks left, the SHUTDOWN receiver MUST continue to follow normal data transmission procedures defined in Section 6, until all outstanding DATA chunks are acknowledged; however, the SHUTDOWN receiver MUST NOT accept new data from its SCTP user.
+未処理のDATAチャンクがまだ残っている場合、SHUTDOWNレシーバーは、すべての未処理のDATAチャンクが確認されるまで、セクション6で定義されている通常のデータ送信手順に従い続ける必要があります。 ただし、SHUTDOWNレシーバーは、SCTPユーザーからの新しいデータを受け入れてはなりません（MUSTNOT）。
         </p>
       </div>
     </div>
@@ -13089,7 +13089,7 @@ The sender of the INIT or COOKIE ECHO should respond to the receipt of a SHUTDOW
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-The sender of the INIT or COOKIE ECHO should respond to the receipt of a SHUTDOWN ACK with a stand-alone SHUTDOWN COMPLETE in an SCTP packet with the Verification Tag field of its common header set to the same tag that was received in the SHUTDOWN ACK packet. This is considered an Out of the Blue packet as defined in Section 8.4. The sender of the INIT lets T1-init continue running and remains in the COOKIE-WAIT or COOKIE-ECHOED state. Normal T1-init timer expiration will cause the INIT or COOKIE chunk to be retransmitted and thus start a new association.
+INITまたはCOOKIEECHOの送信者は、共通ヘッダーの検証タグフィールドがSHUTDOWN ACKパケットで受信されたのと同じタグに設定された、SCTPパケット内のスタンドアロンSHUTDOWNCOMPLETEでSHUTDOWNACKの受信に応答する必要があります。 。 これは、セクション8.4で定義されているように、Out of theBlueパケットと見なされます。 INITの送信者は、T1-initの実行を継続し、COOKIE-WAITまたはCOOKIE-ECHOED状態のままにします。 通常のT1-initタイマーの有効期限が切れると、INITまたはCOOKIEチャンクが再送信され、新しい関連付けが開始されます。
         </p>
       </div>
     </div>
@@ -13379,7 +13379,7 @@ The peer endpoint shall be specified by one of the transport addresses that defi
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-The peer endpoint shall be specified by one of the transport addresses that defines the endpoint (see Section 1.3). If the local SCTP instance has not been initialized, the ASSOCIATE is considered an error.
+ピアエンドポイントは、エンドポイントを定義するトランスポートアドレスの1つによって指定される必要があります（セクション1.3を参照）。 ローカルSCTPインスタンスが初期化されていない場合、ASSOCIATEはエラーと見なされます。
         </p>
       </div>
     </div>
@@ -13916,7 +13916,7 @@ Mandatory attributes:
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-Mandatory attributes:
+必須属性：
         </p>
       </div>
     </div>
@@ -17174,7 +17174,7 @@ The Port Numbers registry should accept registrations for SCTP ports in the Well
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-The Port Numbers registry should accept registrations for SCTP ports in the Well Known Ports and Registered Ports ranges. Well Known and Registered Ports SHOULD NOT be used without registration. Although in some cases -- such as porting an application from TCP to SCTP -- it may seem natural to use an SCTP port before registration completes, we emphasize that IANA will not guarantee registration of particular Well Known and Registered Ports. Registrations should be requested as early as possible.
+ポート番号レジストリは、既知のポートと登録済みポートの範囲のSCTPポートの登録を受け入れる必要があります。 よく知られた登録済みのポートは、登録なしで使用しないでください。 TCPからSCTPへのアプリケーションの移植など、場合によっては、登録が完了する前にSCTPポートを使用するのが自然に思えるかもしれませんが、IANAは特定の既知の登録済みポートの登録を保証しないことを強調します。 登録はできるだけ早くリクエストする必要があります。
         </p>
       </div>
     </div>
@@ -17258,7 +17258,7 @@ o A port name SHOULD NOT be registered for more than one SCTP port number.
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-o A port name SHOULD NOT be registered for more than one SCTP port number.
+o ポート名は複数のSCTPポート番号に登録されるべきではありません（SHOULDNOT）。
         </p>
       </div>
     </div>
@@ -17966,7 +17966,7 @@ IMPLEMENTATION NOTE: Standards documents, textbooks, and vendor literature on CR
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-IMPLEMENTATION NOTE: Standards documents, textbooks, and vendor literature on CRCs often follow an alternative formulation, in which the register used to hold the remainder of the long-division algorithm is initialized to zero rather than all-1s, and instead the first 32 bits of the message are complemented. The long-division algorithm used in our formulation is specified such that the initial multiplication by 2^32 and the long-division are combined into one simultaneous operation. For such algorithms, and for messages longer than 64 bits, the two specifications are precisely equivalent. That equivalence is the intent of this document.
+実装上の注意：CRCに関する標準文書、教科書、およびベンダーの文献は、多くの場合、筆算アルゴリズムの余りを保持するために使用されるレジスタがすべて1ではなくゼロに初期化され、代わりに最初の32ビットに初期化される代替の定式化に従います。 メッセージの補足されます。 私たちの定式化で使用される筆算アルゴリズムは、2 ^ 32による最初の乗算と筆算が1つの同時演算に結合されるように指定されています。 このようなアルゴリズムの場合、および64ビットより長いメッセージの場合、2つの仕様はまったく同じです。 その同等性がこのドキュメントの目的です。
         </p>
       </div>
     </div>
@@ -17990,7 +17990,7 @@ There may be a computational advantage in validating the association against the
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-There may be a computational advantage in validating the association against the Verification Tag, prior to performing a checksum, as invalid tags will result in the same action as a bad checksum in most cases. The exceptions for this technique would be INIT and some SHUTDOWN-COMPLETE exchanges, as well as a stale COOKIE ECHO. These special-case exchanges must represent small packets and will minimize the effect of the checksum calculation.
+ほとんどの場合、無効なタグは不良チェックサムと同じアクションになるため、チェックサムを実行する前に、検証タグに対して関連付けを検証することには計算上の利点がある場合があります。 この手法の例外は、INITと一部のSHUTDOWN-COMPLETE交換、および古いCOOKIEECHOです。 これらの特殊なケースの交換は小さなパケットを表す必要があり、チェックサム計算の影響を最小限に抑えます。
         </p>
       </div>
     </div>
@@ -18147,7 +18147,7 @@ The following non-normative sample code is taken from an open-source CRC generat
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-The following non-normative sample code is taken from an open-source CRC generator [WILLIAMS93], using the &#34;mirroring&#34; technique and yielding a lookup table for SCTP CRC32c with 256 entries, each 32 bits wide. While neither especially slow nor especially fast, as software table-lookup CRCs go, it has the advantage of working on both big-endian and little-endian CPUs, using the same (host-order) lookup tables, and using only the predefined ntohl() and htonl() operations. The code is somewhat modified from [WILLIAMS93], to ensure portability between big-endian and little-endian architectures. (Note that if the byte endian-ness of the target architecture is known to be little-endian, the final bit-reversal and byte-reversal steps can be folded into a single operation.)
+次の非規範的なサンプルコードは、「ミラーリング」を使用して、オープンソースのCRCジェネレーター[WILLIAMS93]から取得したものです。 テクニックと、それぞれ32ビット幅の256エントリを持つSCTPCRC32cのルックアップテーブルを生成します。 ソフトウェアテーブルルックアップCRCが進むにつれて、特に遅くも速くもありませんが、同じ（ホスト順序）ルックアップテーブルを使用し、事前定義されたntohlのみを使用して、ビッグエンディアンとリトルエンディアンの両方のCPUで動作するという利点があります。 （）およびhtonl（）操作。 コードは[WILLIAMS93]から多少変更されており、ビッグエンディアンアーキテクチャとリトルエンディアンアーキテクチャ間の移植性が確保されています。 （ターゲットアーキテクチャのバイトエンディアンがリトルエンディアンであることがわかっている場合は、最後のビット反転とバイト反転のステップを1つの操作に折りたたむことができることに注意してください。）
         </p>
       </div>
     </div>


### PR DESCRIPTION
自分がよく見ている RFC の翻訳漏れがいくつかあったので、手動で追加してみました。

もともとが Google 翻訳を利用されていたので Google 翻訳を利用しています。ライセンス的にグレーと判断した場合は PR を閉じていただいて問題ありません。
