### PR TITLE
WIP: RFC3875(CGI) 意味がとりにくい翻訳を最低限の修正

### DIFF
--- a/html/rfc3875.html
+++ b/html/rfc3875.html
@@ -63,7 +63,7 @@
           </span><br>
           <span class="title_ja">
             タイトル : <strong>RFC 3875 - Common Gatewayインタフェース（CGI）バージョン1.1</strong></span><br>
-          <span class="updated_by">翻訳編集 : 自動生成</span><br>
+          <span class="updated_by">翻訳編集 : 自動生成 + 一部修正</span><br>
         </div>
       </div>
       <div id="rfc_alert" class="col-sm-12 col-md-12 hidden" role="alert">
@@ -199,7 +199,7 @@ The interface has been in use by the World-Wide Web (WWW) since 1993. This speci
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-このインターフェースは、1993年以来ワールドワイドWeb（WWW）によって使用されています。この仕様は、スーパーコンピューティングアプリケーションの米国国立センターに開発および文書化された「CGI / 1.1」インターフェースの「現在の練習」パラメータを定義しています。この文書は、UNIX（R）およびその他のシステムでCGI / 1.1インターフェイスの使用も定義しています。
+このインターフェースは、1993年以来ワールドワイドWeb（WWW）によって使用されています。この仕様は、スーパーコンピューティングアプリケーションの米国国立センターに開発および文書化された「CGI/1.1」インターフェースの「現在の練習」パラメータを定義しています。この文書は、UNIX（R）およびその他のシステムでCGI/1.1インターフェイスの使用も定義しています。
         </p>
       </div>
     </div>
@@ -470,7 +470,7 @@ The key words &#39;MUST&#39;, &#39;MUST NOT&#39;, &#39;REQUIRED&#39;, &#39;SHALL
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-「必須」、「必須」、「必須」、「SEQL」、「推奨する」、「推奨」、「推奨」、「オプション」、「オプション」、「オプション」、「オプション」、「オプショナル」、「オプション」、「オプション」、BCP 14、RFC 2119 [3]に記載されているように解釈される。
+「MUST」、「MUST NOT」、「REQUIRED」、「SHALL」、「SHALL NOT」、「SHOULD」、「SHOULD NOT」、「RECOMMENDED」、「MAY」および「OPTIONAL」はBCP 14、RFC 2119 [3]に記載されているように解釈される。
         </p>
       </div>
     </div>
@@ -556,7 +556,7 @@ This specification uses many terms defined in the HTTP/1.1 specification [4]; ho
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-この仕様では、HTTP / 1.1仕様で定義されている多くの用語を使用しています[4];ただし、以下の用語は、その文書内のそれらの定義とは関係なく、またはそれらの共通の意味ではない意味で、ここで使用されています。
+この仕様では、HTTP/1.1仕様で定義されている多くの用語を使用しています[4];ただし、以下の用語は、その文書内のそれらの定義とは関係なく、またはそれらの共通の意味ではない意味で、ここで使用されています。
         </p>
       </div>
     </div>
@@ -617,7 +617,7 @@ This specification uses many terms defined in the HTTP/1.1 specification [4]; ho
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-2.1. BNFを拡張しました
+2.1. Augmented BNF
         </h5>
       </div>
 
@@ -630,7 +630,7 @@ All of the mechanisms specified in this document are described in both prose and
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-この文書で指定されたすべてのメカニズムは、RFC 822で使用されているものと同様の散文と増強された背景 - ナウル形（BNF）の両方で説明されています[13]。特に記載されていない限り、要素は大文字と小文字が区別されます。この拡張BNFには、次の構成要素が含まれています。
+この文書で指定されたすべてのメカニズムは、RFC 822で使用されているものと同様の散文と増強されたバッカス-ナウア記法（BNF）の両方で説明されています[13]。特に記載されていない限り、要素は大文字と小文字が区別されます。このAugmented BNFには、次の構成要素が含まれています。
         </p>
       </div>
     </div>
@@ -642,7 +642,7 @@ name = definition The name of a rule and its definition are separated by the equ
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-name =定義ルールとその定義の名前は、等文字（ &#39;=&#39;）で区切られています。空白は、定義の継続行がインデントされているという点でのみ重要です。
+name = 定義ルールとその定義の名前は、等文字（&#39;=&#39;）で区切られています。空白は、定義の継続行がインデントされているという点でのみ重要です。
         </p>
       </div>
     </div>
@@ -654,7 +654,7 @@ name =定義ルールとその定義の名前は、等文字（ &#39;=&#39;）�
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-リテラル引用符を除いて、リテラルのテキストを囲みます（ &#39;&lt;&#39;、 &#39;&gt;&#39;）。
+リテラル引用符を除いて、リテラルのテキストを囲みます（&#39;&lt;&#39;、 &#39;&gt;&#39;）。
         </p>
       </div>
     </div>
@@ -678,7 +678,7 @@ rule1 | rule2 Alternative rules are separated by a vertical bar (&#39;|&#39;).
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-（Rule1 Rule2 Rule3）括弧内に囲まれた要素は単一の要素として扱われます。
+（rule1 rule2 rule3） 括弧内に囲まれた要素は単一の要素として扱われます。
         </p>
       </div>
     </div>
@@ -690,7 +690,7 @@ rule1 | rule2 Alternative rules are separated by a vertical bar (&#39;|&#39;).
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-*ルールアスタリスク（ &#39;*&#39;）が先行するルールは、0以上の出現箇所を持つことができます。フルフォームは、ルールの少なくともnと最大のmの出現を示す「n * mのルール」です。nとmはそれぞれ0と無限大のデフォルト値を持つオプションの10進値です。
+*ルールアスタリスク（&#39;*&#39;）が先行するルールは、0以上の出現箇所を持つことができます。フルフォームは、ルールの少なくともnと最大のmの出現を示す「n * mのルール」です。nとmはそれぞれ0と無限大のデフォルト値を持つオプションの10進値です。
         </p>
       </div>
     </div>
@@ -702,7 +702,7 @@ rule1 | rule2 Alternative rules are separated by a vertical bar (&#39;|&#39;).
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-[ルール]角括弧（ &#39;[&#39;と &#39;]&#39;）で囲まれた要素はオプションであり、 &#39;* 1ルール&#39;に相当します。
+[ルール] 角括弧（&#39;[&#39;と &#39;]&#39;）で囲まれた要素はオプションであり、 &#39;* 1ルール&#39;に相当します。
         </p>
       </div>
     </div>
@@ -714,7 +714,7 @@ N rule A rule preceded by a decimal number represents exactly N occurrences of t
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-nルール10進数が前のルールは、ルールの正確にN個の発生を表します。それは &#39;n * nルール&#39;と同じです。
+nルール10進数が前のルールは、ルールの正確にN個の発生を表します。それは &#39;n*nルール&#39;と同じです。
         </p>
       </div>
     </div>
@@ -830,7 +830,7 @@ Some variables and constructs used here are described as being &#39;URL-encoded&
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-ここで使用されるいくつかの変数と構成は、「URLエンコード」として説明されています。この符号化はRFC 2396 [2]の第2章で説明されています。URLエンコードされた文字列では、エスケープシーケンスはパーセント文字（ &#34;％&#34;）とそれに続く2つの16進数字で構成され、ここで2つの16進数はオクテットを形成します。エスケープシーケンスは、存在する場合は、us-ascii [9]コード化文字セット内のコードとしてオクテットを持つグラフィック文字を表します。現在、どの文字セットの非ASCIIコードを表すかを識別するためにURI構文内にプロビジョニングされているため、CGIはこの問題をアドホックに基づいて処理します。
+ここで使用されるいくつかの変数と構成は、「URLエンコード」として説明されています。この符号化はRFC 2396 [2]の第2章で説明されています。URLエンコードされた文字列では、エスケープシーケンスはパーセント文字（ &#34;%&#34;）とそれに続く2つの16進数字で構成され、ここで2つの16進数はオクテットを形成します。エスケープシーケンスは、存在する場合は、us-ascii [9]コード化文字セット内のコードとしてオクテットを持つグラフィック文字を表します。現在、どの文字セットの非ASCIIコードを表すかを識別するためにURI構文内にプロビジョニングされているため、CGIはこの問題をアドホックに基づいて処理します。
         </p>
       </div>
     </div>
@@ -842,7 +842,7 @@ Note that some unsafe (reserved) characters may have different semantics when en
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-符号化されたときに、一部の安全でない（予約済み）文字は異なる意味を持つことがあります。どの文字が安全でないかの定義はコンテキストによって異なります。権威ある治療のために、RFC 2732 [7]によって更新されたRFC 2396 [2]のセクション2を参照のこと。これらの予約された文字は、一般に、フィールド区切り文字として文字列に構文構造を提供するために使用されます。すべての場合において、文字列は最初に存在する予約文字に関して処理され、結果として得られるデータは &#34;％&#34;エスケープシーケンスを文字値で置き換えることによってURLデコードされます。
+符号化されたときに、一部の安全でない（予約済み）文字は異なる意味を持つことがあります。どの文字が安全でないかの定義はコンテキストによって異なります。権威ある治療のために、RFC 2732 [7]によって更新されたRFC 2396 [2]のセクション2を参照のこと。これらの予約された文字は、一般に、フィールド区切り文字として文字列に構文構造を提供するために使用されます。すべての場合において、文字列は最初に存在する予約文字に関して処理され、結果として得られるデータは &#34;%&#34;エスケープシーケンスを文字値で置き換えることによってURLデコードされます。
         </p>
       </div>
     </div>
@@ -854,7 +854,7 @@ To encode a character string, all reserved and forbidden characters are replaced
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-文字列をエンコードするために、すべての予約された文字と禁止文字は対応する &#34;％&#34;エスケープシーケンスに置き換えられます。その後、文字列をURIの組み立てに使用できます。予約された文字はコンテキストごとに異なりますが、常にこのセットから描画されます。
+文字列をエンコードするために、すべての予約された文字と禁止文字は対応する &#34;%&#34;エスケープシーケンスに置き換えられます。その後、文字列をURIの組み立てに使用できます。予約された文字はコンテキストごとに異なりますが、常にこのセットから描画されます。
         </p>
       </div>
     </div>
@@ -998,7 +998,7 @@ Information about this split of the path is available to the script in the meta-
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-3.3. スクリプトウリ
+3.3. Script-URI
         </h5>
       </div>
 
@@ -1092,7 +1092,7 @@ See section 4.1.5 for more information about the PATH_INFO meta-variable.
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-path_infoメタ変数の詳細については、セクション4.1.5を参照してください。
+PATH_INFOメタ変数の詳細については、セクション4.1.5を参照してください。
         </p>
       </div>
     </div>
@@ -1104,7 +1104,7 @@ The scheme and the protocol are not identical as the scheme identifies the acces
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-スキームとプロトコルは、この方式がアプリケーションプロトコルに加えてアクセス方式を識別するものと同じではありません。たとえば、トランスポートレイヤセキュリティ（TLS）[14]を使用してアクセスされるリソースは、HTTPプロトコル[19]を使用するときにHTTPSの方式を持つリクエストURIを持ちます。CGI / 1.1は、スクリプトがこれを再構築するための一般的な手段を提供しません。したがって、定義されたScript-URIには、使用されている基本プロトコルが含まれます。ただし、スクリプトは、URIスキームをよりよく推定するためにスキーム固有のメタ変数を利用することができます。
+スキームとプロトコルは、この方式がアプリケーションプロトコルに加えてアクセス方式を識別するものと同じではありません。たとえば、Transport Layer Security(TLS）[14]を使用してアクセスされるリソースは、HTTPプロトコル[19]を使用するときにHTTPSの方式を持つリクエストURIを持ちます。CGI/1.1は、スクリプトがこれを再構築するための一般的な手段を提供しません。したがって、定義されたScript-URIには、使用されている基本プロトコルが含まれます。ただし、スクリプトは、URIスキームをよりよく推定するためにスキーム固有のメタ変数を利用することができます。
         </p>
       </div>
     </div>
@@ -1248,7 +1248,7 @@ The server MAY set additional implementation-defined extension meta-variables, w
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-サーバーは、追加の実装定義定義内容メタ変数を設定します。その名前の先頭に &#34;x_&#34;を付ける必要があります。
+サーバーは、追加の実装定義定義内容メタ変数を設定します。その名前の先頭に &#34;X_&#34;を付ける必要があります。
         </p>
       </div>
     </div>
@@ -1260,7 +1260,7 @@ This specification does not distinguish between zero-length (NULL) values and mi
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-この仕様は、ゼロ長（NULL）値と欠損値を区別しません。たとえば、スクリプトは、2つの要求http：// host / scriptとhttp：// host / scriptを区別できませんか？どちらの場合も、query_stringメタ変数はnullになります。
+この仕様は、ゼロ長（NULL）値と欠損値を区別しません。たとえば、スクリプトは、2つの要求 http：//host/script と http：//host/script? を区別できません。どちらの場合も、QUERY_STRINGメタ変数はNULLになります。
         </p>
       </div>
     </div>
@@ -1292,7 +1292,7 @@ An optional meta-variable may be omitted (left unset) if its value is NULL. Meta
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.1. auth_type.
+4.1.1. AUTH_TYPE
         </h5>
       </div>
 
@@ -1305,7 +1305,7 @@ The AUTH_TYPE variable identifies any mechanism used by the server to authentica
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-auth_type変数は、ユーザを認証するためにサーバによって使用される任意のメカニズムを識別します。クライアントプロトコルまたはサーバー実装によって定義された大文字と小文字を区別しない値が含まれています。
+AUTH_TYPE変数は、ユーザを認証するためにサーバによって使用される任意のメカニズムを識別します。クライアントプロトコルまたはサーバー実装によって定義された大文字と小文字を区別しない値が含まれています。
         </p>
       </div>
     </div>
@@ -1351,7 +1351,7 @@ HTTPアクセス認証方式はRFC 2617 [5]に記載されています。
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.2. content_length.
+4.1.2. CONTENT_LENGTH
         </h5>
       </div>
 
@@ -1364,19 +1364,14 @@ The CONTENT_LENGTH variable contains the size of the message-body attached to th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-content_length変数には、10進数のオクテット数で、要求に添付されているメッセージ本文のサイズが含まれます。データが添付されていない場合は、NULL（または設定解除）します。
+CONTENT_LENGTH変数には、10進数のオクテット数で、要求に添付されているメッセージ本文のサイズが含まれます。データが添付されていない場合は、NULL（または設定解除）します。
         </p>
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 CONTENT_LENGTH = &#34;&#34; | 1*digit
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-content_length = &#34;&#34;
         </p>
       </div>
     </div>
@@ -1388,7 +1383,7 @@ The server MUST set this meta-variable if and only if the request is accompanied
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-要求にメッセージボディエンティティが伴っている場合に限り、サーバーはこのメタ変数を設定する必要があります。content_length値は、サーバーが転送コードまたはコンテンツコーディングを削除した後にメッセージ本文の長さを反映している必要があります。
+要求にメッセージボディエンティティが伴っている場合に限り、サーバーはこのメタ変数を設定する必要があります。CONTENT_LENGTH値は、サーバーが転送コードまたはコンテンツコーディングを削除した後にメッセージ本文の長さを反映している必要があります。
         </p>
       </div>
     </div>
@@ -1400,7 +1395,7 @@ The server MUST set this meta-variable if and only if the request is accompanied
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.3. content_type.
+4.1.3. CONTENT_TYPE
         </h5>
       </div>
 
@@ -1413,7 +1408,7 @@ If the request includes a message-body, the CONTENT_TYPE variable is set to the 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-要求にメッセージ本体が含まれている場合、content_type変数はメッセージ本文のインターネットメディアタイプ[6]に設定されます。
+要求にメッセージ本体が含まれている場合、CONTENT_TYPE変数はメッセージ本文のインターネットメディアタイプ[6]に設定されます。
         </p>
       </div>
     </div>
@@ -1439,7 +1434,7 @@ The type, subtype and parameter attribute names are not case-sensitive. Paramete
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-型、サブタイプ、およびパラメータ属性名は大文字と小文字を区別しません。パラメータ値は大文字と小文字が区別される場合があります。メディアタイプとHTTPでの使用は、http / 1.1仕様のセクション3.7で説明されています[4]。
+型、サブタイプ、およびパラメータ属性名は大文字と小文字を区別しません。パラメータ値は大文字と小文字が区別される場合があります。メディアタイプとHTTPでの使用は、HTTP/1.1仕様のセクション3.7で説明されています[4]。
         </p>
       </div>
     </div>
@@ -1451,7 +1446,7 @@ There is no default value for this variable. If and only if it is unset, then th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-この変数にはデフォルト値はありません。設定されていない場合に限り、スクリプトは受信したデータからメディアの種類を判断しようとします。タイプが不明なままである場合、スクリプトはアプリケーション/オクテットストリームの種類を引き受けるか、（6.3.3項で説明されているように）要求をエラーで拒否することができます。
+この変数にはデフォルト値はありません。設定されていない場合に限り、スクリプトは受信したデータからメディアの種類を判断しようとします。タイプが不明なままである場合、スクリプトはapplication/octet-streamの種類を引き受けるか、（6.3.3項で説明されているように）要求をエラーで拒否することができます。
         </p>
       </div>
     </div>
@@ -1511,7 +1506,7 @@ There is no default value for this variable. If and only if it is unset, then th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-6">
-4. デフォルトはUSCIIです。
+4. デフォルトはUS-ASCIIです。
         </p>
       </div>
     </div>
@@ -1535,7 +1530,7 @@ HTTP Content-Typeフィールドがクライアント要求ヘッダーに存在
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.4. gateway_interface
+4.1.4. GATEWAY_INTERFACE
         </h5>
       </div>
 
@@ -1548,7 +1543,7 @@ The GATEWAY_INTERFACE variable MUST be set to the dialect of CGI being used by t
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-gateway_interface変数は、スクリプトと通信するためにサーバーによって使用されているCGIの方言に設定する必要があります。構文：
+GATEWAY_INTERFACE変数は、スクリプトと通信するためにサーバーによって使用されているCGIの方言に設定する必要があります。構文：
         </p>
       </div>
     </div>
@@ -1568,7 +1563,7 @@ Note that the major and minor numbers are treated as separate integers and hence
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-メジャー番号とマイナー番号は別々の整数として扱われているため、それぞれ1桁より高い増分されてもよい。したがって、CGI / 2.4はCGI / 2.13より低いバージョンであり、これはCGI / 12.3より低い。先行ゼロはスクリプトによって無視される必要があり、サーバーによって生成されないでください。
+メジャー番号とマイナー番号は別々の整数として扱われているため、それぞれ1桁より高い増分されてもよい。したがって、CGI/2.4はCGI/2.13より低いバージョンであり、これはCGI/12.3より低い。先行ゼロはスクリプトによって無視される必要があり、サーバーによって生成されないでください。
         </p>
       </div>
     </div>
@@ -1592,7 +1587,7 @@ This document defines the 1.1 version of the CGI interface.
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.5. path_info
+4.1.5. PATH_INFO
         </h5>
       </div>
 
@@ -1605,7 +1600,7 @@ The PATH_INFO variable specifies a path to be interpreted by the CGI script. It 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-path_info変数は、CGIスクリプトによって解釈されるパスを指定します。CGIスクリプトによって返されるリソースまたはサブリソースを識別し、スクリプト自体を識別する部分に従ってURIパス階層の一部から派生します。URIパスとは異なり、PATH_INFOはURLエンコードされていないため、パスセグメントパラメータを含めることはできません。&#34;/&#34;のpath_infoは単一のボイドパスセグメントを表します。
+path_info変数は、CGIスクリプトによって解釈されるパスを指定します。CGIスクリプトによって返されるリソースまたはサブリソースを識別し、スクリプト自体を識別する部分に従ってURIパス階層の一部から派生します。URIパスとは異なり、PATH_INFOはURLエンコードされていないため、パスセグメントパラメータを含めることはできません。&#34;/&#34;のPATH_INFOは単一のボイドパスセグメントを表します。
         </p>
       </div>
     </div>
@@ -1640,7 +1635,7 @@ URL-encoded, the PATH_INFO string forms the extra-path component of the Script-U
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-URLエンコードされたPATH_INFO文字列は、そのパスのscript_name部分に続くscript-uri（セクション3.3を参照）のentr-pathコンポーネントを形成します。
+URLエンコードされたPATH_INFO文字列は、そのパスのSCRIPT_NAME部分に続くScript-URI（セクション3.3を参照）のextra-pathコンポーネントを形成します。
         </p>
       </div>
     </div>
@@ -1652,7 +1647,7 @@ URLエンコードされたPATH_INFO文字列は、そのパスのscript_name部
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.6. path_translate
+4.1.6. PATH_TRANSLATED
         </h5>
       </div>
 
@@ -1665,7 +1660,7 @@ The PATH_TRANSLATED variable is derived by taking the PATH_INFO value, parsing i
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-path_translated変数は、PATH_INFO値を取得し、それを自分の権利でローカルURIとして解析し、それをサーバーのドキュメントリポジトリ構造にマッピングするのに適した仮想間の変換を実行することによって導出されます。結果で許可されている文字セットはシステム定義です。
+PATH_TRANSLATED変数は、PATH_INFO値を取得し、それを自分の権利でローカルURIとして解析し、それをサーバーのドキュメントリポジトリ構造にマッピングするのに適した仮想間の変換を実行することによって導出されます。結果で許可されている文字セットはシステム定義です。
         </p>
       </div>
     </div>
@@ -1725,19 +1720,14 @@ would result in a PATH_INFO value of
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-path_info値をもたらすでしょう
+PATH_INFO値をもたらすでしょう
         </p>
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 /this.is.the.path;info
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-/ this.the.path.path.info.
         </p>
       </div>
     </div>
@@ -1789,7 +1779,7 @@ The value of PATH_TRANSLATED is the result of the translation.
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-path_translatedの値は翻訳の結果です。
+PATH_TRANSLATEDの値は翻訳の結果です。
         </p>
       </div>
     </div>
@@ -1825,7 +1815,7 @@ The server SHOULD set this meta-variable if the request URI includes a path-info
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-要求URIにパス情報コンポーネントが含まれている場合、サーバーはこのメタ変数を設定する必要があります。path_infoがnullの場合、path_translated変数はnull（または未設定）に設定する必要があります。
+要求URIにパス情報コンポーネントが含まれている場合、サーバーはこのメタ変数を設定する必要があります。PATH_INFOがnullの場合、PATH_TRANSLATED変数はNULL（または未設定）に設定する必要があります。
         </p>
       </div>
     </div>
@@ -1837,7 +1827,7 @@ The server SHOULD set this meta-variable if the request URI includes a path-info
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.7. クエリ文字列
+4.1.7. QUERY_STRING
         </h5>
       </div>
 
@@ -1850,7 +1840,7 @@ The QUERY_STRING variable contains a URL-encoded search or parameter string; it 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-query_string変数には、URLエンコードされた検索またはパラメータ文字列が含まれています。スクリプトによって返される文書に影響を与えるか、CGIスクリプトに情報を提供します。
+QUERY_STRING変数には、URLエンコードされた検索またはパラメータ文字列が含まれています。スクリプトによって返される文書に影響を与えるか、CGIスクリプトに情報を提供します。
         </p>
       </div>
     </div>
@@ -1862,7 +1852,7 @@ The URL syntax for a search string is described in section 3 of RFC 2396 [2]. Th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-検索文字列のURL構文は、RFC 2396 [2]のセクション3で説明されています。query_string値では大文字と小文字が区別されます。
+検索文字列のURL構文は、RFC 2396 [2]のセクション3で説明されています。QUERY_STRING値では大文字と小文字が区別されます。
         </p>
       </div>
     </div>
@@ -1884,7 +1874,7 @@ When parsing and decoding the query string, the details of the parsing, reserved
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-クエリ文字列を解析および復号化するとき、解析、予約文字、およびUSCII以外の文字のサポートの詳細は、コンテキストによって異なります。たとえば、HTML文書からのフォーム送信[18]は、文字 &#34;&#34;、 &#34;＆&#34;、 &#34;=&#34;が予約されており、ISO 8859-1エンコーディングがある場合があります。US-ASCII文字以外の文字に使用されます。
+クエリ文字列を解析および復号化するとき、解析、予約文字、およびUS-ASCII以外の文字のサポートの詳細は、コンテキストによって異なります。たとえば、application/x-www-form-urlencodedを使用したHTML文書からのフォーム送信[18]は、文字 &#34;+&#34;、 &#34;&amp;&#34;、 &#34;=&#34;が予約されており、ISO 8859-1エンコーディングがある場合があります。US-ASCII文字以外の文字に使用されます。
         </p>
       </div>
     </div>
@@ -1896,7 +1886,7 @@ The QUERY_STRING value provides the query-string part of the Script-URI. (See se
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-query_string値は、スクリプト-URIの照会列部分を提供します。（3.3項を参照）。
+QUERY_STRING値は、スクリプト-URIの照会列部分を提供します。（3.3項を参照）。
         </p>
       </div>
     </div>
@@ -1908,7 +1898,7 @@ The server MUST set this variable; if the Script-URI does not include a query co
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-サーバーはこの変数を設定する必要があります。script-uriにクエリコンポーネントが含まれていない場合、query_stringは空の文字列（ &#34;&#34;）として定義する必要があります。
+サーバーはこの変数を設定する必要があります。Script-URIにクエリコンポーネントが含まれていない場合、QUERY_STRINGは空の文字列（&#34;&#34;）として定義する必要があります。
         </p>
       </div>
     </div>
@@ -1920,7 +1910,7 @@ The server MUST set this variable; if the Script-URI does not include a query co
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.8. remote_addr.
+4.1.8. REMOTE_ADDR
         </h5>
       </div>
 
@@ -1970,7 +1960,7 @@ IPv6アドレスのフォーマットはRFC 3513 [15]に記載されています
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.9. リモートホスト
+4.1.9. REMOTE_HOST
         </h5>
       </div>
 
@@ -2019,7 +2009,7 @@ The server SHOULD set this variable. If the hostname is not available for perfor
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.10. remote_ident.
+4.1.10. REMOTE_IDENT
         </h5>
       </div>
 
@@ -2064,7 +2054,7 @@ The data returned may be used for authentication purposes, but the level of trus
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.11. remote_user
+4.1.11. REMOTE_USER
         </h5>
       </div>
 
@@ -2097,7 +2087,7 @@ If the client request required HTTP Authentication [5] (e.g., the AUTH_TYPE meta
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-クライアント要求がHTTP認証を要求した場合[5]（例えば、auth_typeメタ変数が &#34;Basic&#34;または &#34;Digest&#34;に設定されています）、remote_userメタ変数の値は指定されたuser-idに設定する必要があります。
+クライアント要求がHTTP認証を要求した場合[5]（例えば、AUTH_TYPEメタ変数が &#34;Basic&#34;または &#34;Digest&#34;に設定されています）、REMOTE_USERメタ変数の値は指定されたuser-IDに設定する必要があります。
         </p>
       </div>
     </div>
@@ -2109,7 +2099,7 @@ If the client request required HTTP Authentication [5] (e.g., the AUTH_TYPE meta
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.12. request_method
+4.1.12. REQUEST_METHOD
         </h5>
       </div>
 
@@ -2122,7 +2112,7 @@ The REQUEST_METHOD meta-variable MUST be set to the method which should be used 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-request_methodメタ変数は、セクション4.3で説明されているように、要求を処理するためにスクリプトによって使用されるべきメソッドに設定する必要があります。
+REQUEST_METHODメタ変数は、セクション4.3で説明されているように、要求を処理するためにスクリプトによって使用されるべきメソッドに設定する必要があります。
         </p>
       </div>
     </div>
@@ -2144,7 +2134,7 @@ The method is case sensitive. The HTTP methods are described in section 5.1.1 of
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-この方法では大文字と小文字が区別されます。HTTPメソッドは、http / 1.1仕様書[4]のhttp / 1.0仕様[1]およびセクション5.1.1のセクション5.1.1で説明されています[4]。
+この方法では大文字と小文字が区別されます。HTTPメソッドは、http/1.1仕様書[4]のhttp/1.0仕様[1]およびセクション5.1.1のセクション5.1.1で説明されています[4]。
         </p>
       </div>
     </div>
@@ -2169,19 +2159,14 @@ The SCRIPT_NAME variable MUST be set to a URI path (not URL-encoded) which could
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-script_name変数は、（スクリプトの出力ではなく）CGIスクリプトを識別できるURIパス（URLエンコードされていない）に設定する必要があります。構文はpath_infoと同じです（セクション4.1.5）。
+SCRIPT_NAME変数は、（スクリプトの出力ではなく）CGIスクリプトを識別できるURIパス（URLエンコードされていない）に設定する必要があります。構文はPATH_INFOと同じです（セクション4.1.5）。
         </p>
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 SCRIPT_NAME = &#34;&#34; | ( &#34;/&#34; path )
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-script_name = &#34;&#34;
         </p>
       </div>
     </div>
@@ -2205,7 +2190,7 @@ The SCRIPT_NAME string forms some leading part of the path component of the Scri
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-script_name文字列は、いくつかの実装定義の方法で派生したスクリプト-URIのパスコンポーネントの先頭部分を形成します。script_name値には、path_infoセグメント（4.1.5項を参照）が含まれていません。
+SCRIPT_NAME文字列は、いくつかの実装定義の方法で派生したスクリプト-URIのパスコンポーネントの先頭部分を形成します。SCRIPT_NAME値には、PATH_INFOセグメント（4.1.5項を参照）が含まれていません。
         </p>
       </div>
     </div>
@@ -2217,7 +2202,7 @@ script_name文字列は、いくつかの実装定義の方法で派生したス
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.14. サーバー名
+4.1.14. SERVER_NAME
         </h5>
       </div>
 
@@ -2230,19 +2215,14 @@ The SERVER_NAME variable MUST be set to the name of the server host to which the
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-server_name変数は、クライアント要求が指示されているサーバーホストの名前に設定する必要があります。それは大文字と小文字を区別しないホスト名またはネットワークアドレスです。スクリプト-URIのホスト部分を形成します。
+SERVER_NAME変数は、クライアント要求が指示されているサーバーホストの名前に設定する必要があります。それは大文字と小文字を区別しないホスト名またはネットワークアドレスです。Script-URIのホスト部分を形成します。
         </p>
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 SERVER_NAME = server-name server-name = hostname | ipv4-address | ( &#34;[&#34; ipv6-address &#34;]&#34; )
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-server_name = server-name server-name = hostname
         </p>
       </div>
     </div>
@@ -2279,19 +2259,14 @@ The SERVER_PORT variable MUST be set to the TCP/IP port number on which this req
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-server_port変数は、クライアントからこの要求を受信したTCP / IPポート番号に設定する必要があります。この値は、スクリプト-URIのポート部分で使用されます。
+SERVER_PORT変数は、クライアントからこの要求を受信したTCP/IPポート番号に設定する必要があります。この値は、Script-URIのポート部分で使用されます。
         </p>
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 SERVER_PORT = server-port server-port = 1*digit
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-server_port = server-port server-port = 1 *桁
         </p>
       </div>
     </div>
@@ -2315,7 +2290,7 @@ Note that this variable MUST be set, even if the port is the default port for th
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.16. server_protocol.
+4.1.16. SERVER_PROTOCOL
         </h5>
       </div>
 
@@ -2328,7 +2303,7 @@ The SERVER_PROTOCOL variable MUST be set to the name and version of the applicat
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-server_protocol変数は、このCGI要求に使用されるアプリケーションプロトコルの名前とバージョンに設定する必要があります。これは、クライアントとの通信でサーバーによって使用されるプロトコルバージョンとは異なる場合があります。
+SERVER_PROTOCOL変数は、このCGI要求に使用されるアプリケーションプロトコルの名前とバージョンに設定する必要があります。これは、クライアントとの通信でサーバーによって使用されるプロトコルバージョンとは異なる場合があります。
         </p>
       </div>
     </div>
@@ -2351,7 +2326,7 @@ Here, &#39;protocol&#39; defines the syntax of some of the information passing b
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-ここで、 &#39;protocol&#39;は、サーバーとスクリプトの間の渡しの一部のシンタックスを定義します（ &#39;プロトコル固有の&#39;機能）。大文字と小文字が区別されず、通常大文字で表示されます。プロトコルはスクリプトURIのスキーム部分と同じではありません。これは、クライアントがサーバーと通信するために使用される全体的なアクセスメカニズムを定義します。たとえば、「HTTP」のプロトコルでスクリプトに到達する要求は、「HTTPS」方式を使用している可能性があります。
+ここで、 &#39;protocol&#39;は、サーバーとスクリプトの間の渡しの一部のシンタックスを定義します（ &#39;プロトコル固有の&#39;機能）。大文字と小文字が区別されず、通常大文字で表示されます。プロトコルはScript-URIのスキーム部分と同じではありません。これは、クライアントがサーバーと通信するために使用される全体的なアクセスメカニズムを定義します。たとえば、「HTTP」のプロトコルでスクリプトに到達する要求は、「HTTPS」方式を使用している可能性があります。
         </p>
       </div>
     </div>
@@ -2363,7 +2338,7 @@ A well-known value for SERVER_PROTOCOL which the server MAY use is &#34;INCLUDED
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-サーバーが使用できるSERVER_PROTOCOLの有名な値は「含まれています」は「Client」であることが、クライアント要求の直接ターゲットではなく、コンポジットドキュメントの一部として含まれていることを示します。スクリプトはこれをHTTP / 1.0要求として扱うべきです。
+サーバーが使用できるSERVER_PROTOCOLの有名な値は「含まれています」は「Client」であることが、クライアント要求の直接ターゲットではなく、コンポジットドキュメントの一部として含まれていることを示します。スクリプトはこれをHTTP/1.0要求として扱うべきです。
         </p>
       </div>
     </div>
@@ -2375,7 +2350,7 @@ A well-known value for SERVER_PROTOCOL which the server MAY use is &#34;INCLUDED
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.1.17. server_software
+4.1.17. SERVER_SOFTWARE
         </h5>
       </div>
 
@@ -2425,7 +2400,7 @@ The server SHOULD set meta-variables specific to the protocol and scheme for the
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-サーバーは、要求のプロトコルとスキームに固有のメタ変数を設定する必要があります。プロトコル固有の変数の解釈は、server_protocolのプロトコルバージョンによって異なります。スキームがプロトコルと同じではない場合、サーバは、スキームの名前をNULL値以外の値に設定してメタ変数を設定することができる。そのような変数の存在は、要求によってスキームが使用されるスクリプトを示す。
+サーバーは、要求のプロトコルとスキームに固有のメタ変数を設定する必要があります。プロトコル固有の変数の解釈は、SERVER_PROTOCOLのプロトコルバージョンによって異なります。スキームがプロトコルと同じではない場合、サーバは、スキームの名前をNULL値以外の値に設定してメタ変数を設定することができる。そのような変数の存在は、要求によってスキームが使用されるスクリプトを示す。
         </p>
       </div>
     </div>
@@ -2437,7 +2412,7 @@ Meta-variables with names beginning with &#34;HTTP_&#34; contain values read fro
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-使用されるプロトコルがHTTPである場合、 &#34;http_&#34;で始まる名前を持つメタ変数は、クライアント要求ヘッダーフィールドから読み取られた値を含みます。HTTPヘッダーフィールド名は大文字に変換され、すべての出現箇所が &#34;_&#34;に置き換えられ、 &#34;http_&#34;がメタ変数名に入れる前に &#34;http_&#34;を追加しています。ヘッダデータはクライアントによって送信されるように提示され得るか、またはその意味を変更しない方法で書き換えることができる。同じフィールド名を持つ複数のヘッダーフィールドが受信された場合、サーバーはそれらを同じセマンティクスを持つ単一の値として書き換える必要があります。同様に、複数の行にスパンするヘッダフィールドを1行にマージする必要があります。サーバーは、必要に応じて、CGIメタ変数に適したデータの表現（文字セットなど）を変更する必要があります。
+使用されるプロトコルがHTTPである場合、 &#34;HTTP_&#34;で始まる名前を持つメタ変数は、クライアント要求ヘッダーフィールドから読み取られた値を含みます。HTTPヘッダーフィールド名は大文字に変換され、すべての出現箇所が &#34;_&#34;に置き換えられ、 &#34;http_&#34;がメタ変数名に入れる前に &#34;HTTP_&#34;を追加しています。ヘッダデータはクライアントによって送信されるように提示され得るか、またはその意味を変更しない方法で書き換えることができます。同じフィールド名を持つ複数のヘッダーフィールドが受信された場合、サーバーはそれらを同じセマンティクスを持つ単一の値として書き換える必要があります。同様に、複数の行にスパンするヘッダフィールドを1行にマージする必要があります。サーバーは、必要に応じて、CGIメタ変数に適したデータの表現（文字セットなど）を変更する必要があります。
         </p>
       </div>
     </div>
@@ -2449,7 +2424,7 @@ The server is not required to create meta-variables for all the header fields th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-サーバーは、受信したすべてのヘッダーフィールドに対してメタ変数を作成する必要はありません。特に、「承認」などの認証情報を搬送するヘッダーフィールドを削除する必要があります。あるいは、 &#39;content-length&#39;と &#39;content-type&#39;など、他の変数のスクリプトで利用可能です。サーバーは、「接続」などのクライアント側の通信の問題のみに関連するヘッダーフィールドを削除することがあります。
+サーバーは、受信したすべてのヘッダーフィールドに対してメタ変数を作成する必要はありません。特に、「承認」などの認証情報を搬送するヘッダーフィールドを削除する必要があります。あるいは、 &#39;Content-Length&#39;と &#39;Content-Type&#39;など、他の変数のスクリプトで利用可能です。サーバーは、「接続」などのクライアント側の通信の問題のみに関連するヘッダーフィールドを削除することがあります。
         </p>
       </div>
     </div>
@@ -2496,7 +2471,7 @@ A request-body is supplied with the request if the CONTENT_LENGTH is not NULL. T
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-content_lengthがnullではない場合、要求ボディに要求が付属しています。サーバーは、少なくともスクリプトが読み取るために利用可能なその多くのバイトを作成する必要があります。Content_Lengthバイトが読み込まれた後、サーバーはファイルの終わり条件を通知したり、拡張データを供給してもよい。したがって、より多くのデータが利用可能であっても、スクリプトはcontent_lengthバイトを読み込もうとしてはならない。ただし、データのいずれかを読む義務がありません。
+CONTENT_LENGTHがNULLではない場合、要求ボディに要求が付属しています。サーバーは、少なくともスクリプトが読み取るために利用可能なその多くのバイトを作成する必要があります。CONTENT_LENGTHバイトが読み込まれた後、サーバーはファイルの終わり条件を通知したり、拡張データを供給してもよい。したがって、より多くのデータが利用可能であっても、スクリプトはCONTENT_LENGTHバイトを読み込もうとしてはならない。ただし、データのいずれかを読む義務がありません。
         </p>
       </div>
     </div>
@@ -2520,7 +2495,7 @@ As transfer-codings are not supported on the request-body, the server MUST remov
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-転送コーディングは要求 - 本文でサポートされていないので、サーバはメッセージ本文からそのようなコードを削除し、content_lengthを再計算する必要があります。これが不可能な場合（たとえば、バッファリング要件が大きいため）、サーバーはクライアント要求を拒否する必要があります。メッセージ本文からコンテンツコーディングを削除することもできます。
+転送コーディングはリクエストボディでサポートされていないので、サーバはメッセージ本文からそのようなコードを削除し、CONTENT_LENGTHを再計算する必要があります。これが不可能な場合（たとえば、バッファリング要件が大きいため）、サーバーはクライアント要求を拒否する必要があります。メッセージ本文からコンテンツコーディングを削除することもできます。
         </p>
       </div>
     </div>
@@ -2545,7 +2520,7 @@ The Request Method, as supplied in the REQUEST_METHOD meta-variable, identifies 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-request_methodメタ変数で指定された要求方法は、応答を生成する際にスクリプトによって適用される処理方法を識別します。スクリプト作成者は、特定のアプリケーションに最も適したメソッドを実装することを選択できます。スクリプトがメソッドを使用して要求を受信した場合、それはそれをサポートしていません。エラーで拒否する必要があります（6.3.3項を参照）。
+REQUEST_METHODメタ変数で指定された要求方法は、応答を生成する際にスクリプトによって適用される処理方法を識別します。スクリプト作成者は、特定のアプリケーションに最も適したメソッドを実装することを選択できます。スクリプトがメソッドを使用して要求を受信した場合、それはそれをサポートしていません。エラーで拒否する必要があります（6.3.3項を参照）。
         </p>
       </div>
     </div>
@@ -2557,7 +2532,7 @@ request_methodメタ変数で指定された要求方法は、応答を生成す
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.3.1. 取得する
+4.3.1. GET
         </h5>
       </div>
 
@@ -2594,7 +2569,7 @@ GETメソッドの意味は、プロトコル固有のメタ変数によって�
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.3.2. 役職
+4.3.2. POST
         </h5>
       </div>
 
@@ -2619,7 +2594,7 @@ The script MUST check the value of the CONTENT_LENGTH variable before reading th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-スクリプトは、接続されているメッセージ本文を読み込む前にcontent_length変数の値をチェックし、処理前にcontent_type値を確認する必要があります。
+スクリプトは、接続されているメッセージ本文を読み込む前にCONTENT_LENGTH変数の値をチェックし、処理前にCONTENT_TYPE値を確認する必要があります。
         </p>
       </div>
     </div>
@@ -2631,7 +2606,7 @@ The script MUST check the value of the CONTENT_LENGTH variable before reading th
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.3.3. 頭
+4.3.3. HEAD
         </h5>
       </div>
 
@@ -2644,7 +2619,7 @@ The HEAD method requests the script to do sufficient processing to return the re
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-ヘッドメソッドは、応答メッセージ本文を提供することなく、応答ヘッダフィールドを返すのに十分な処理を実行するようにスクリプトに要求する。スクリプトは、ヘッド要求の応答メッセージ本文を提供してはいけません。そうであれば、サーバーはスクリプトからの応答を読むときにメッセージ本文を破棄する必要があります。
+HEADメソッドは、応答メッセージ本文を提供することなく、応答ヘッダフィールドを返すのに十分な処理を実行するようにスクリプトに要求する。スクリプトは、ヘッド要求の応答メッセージ本文を提供してはいけません。そうであれば、サーバーはスクリプトからの応答を読むときにメッセージ本文を破棄する必要があります。
         </p>
       </div>
     </div>
@@ -2656,7 +2631,7 @@ The HEAD method requests the script to do sufficient processing to return the re
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-4.3.4. プロトコル固有の方法
+4.3.4. プロトコル固有のメソッド
         </h5>
       </div>
 
@@ -2669,7 +2644,7 @@ The script MAY implement any protocol-specific method, such as HTTP/1.1 PUT and 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-スクリプトは、HTTP / 1.1のPUTおよびDELETEなどのプロトコル固有の方法を実装することができます。そうするときはserver_protocolの値を確認する必要があります。
+スクリプトは、HTTP/1.1のPUTおよびDELETEなどのプロトコル固有の方法を実装することができます。そうするときはSERVER_PROTOCOLの値を確認する必要があります。
         </p>
       </div>
     </div>
@@ -2706,7 +2681,7 @@ Some systems support a method for supplying an array of strings to the CGI scrip
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-一部のシステムは、CGIスクリプトに文字列の配列を供給する方法をサポートしています。これは &#39;索引付けされた&#39; http queryの場合にのみ使用されます。これは、符号を付けられていない &#34;=&#34;文字を含まないURIクエリ文字列を持つ &#39;get&#39;または &#39;head&#39;要求によって識別されます。そのような要求の場合、サーバーはクエリ文字列を検索文字列として扱い、ルールを使用して単語に解析する必要があります。
+一部のシステムは、CGIスクリプトに文字列の配列を供給する方法をサポートしています。これは &#39;索引付けされた&#39; HTTPクエリの場合にのみ使用されます。これは、符号を付けられていない &#34;=&#34;文字を含まないURIクエリ文字列を持つ &#39;get&#39;または &#39;head&#39;要求によって識別されます。そのような要求の場合、サーバーはクエリ文字列を検索文字列として扱い、ルールを使用して単語に解析する必要があります。
         </p>
       </div>
     </div>
@@ -2754,7 +2729,7 @@ The script SHOULD check to see if the QUERY_STRING value contains an unencoded &
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-スクリプトは、query_string値にuncoded &#34;=&#34;文字が含まれているかどうかを確認する必要があり、そのコマンドライン引数を使用しないでください。
+スクリプトは、QUERY_STRING値にエンコードされていない&#34;=&#34;文字が含まれているかどうかを確認する必要があり、そのコマンドライン引数を使用しないでください。
         </p>
       </div>
     </div>
@@ -2841,7 +2816,7 @@ Currently, NPH scripts are only defined for HTTP client requests. An (HTTP) NPH 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-現在、NPHスクリプトはHTTPクライアント要求に対してのみ定義されています。（HTTP）NPHスクリプトは、現在、HTTP仕様[1]、[4]のセクション6で説明している完全なHTTP応答メッセージを返す必要があります。スクリプトはserver_protocol変数を使用して応答の適切な形式を決定する必要があります。特定のプロトコル仕様によって義務付けられている可能性があるように、要求内の一般的またはプロトコル固有のメタ変数を考慮に入れる必要があります。
+現在、NPHスクリプトはHTTPクライアント要求に対してのみ定義されています。（HTTP）NPHスクリプトは、現在、HTTP仕様[1]、[4]のセクション6で説明している完全なHTTP応答メッセージを返す必要があります。スクリプトはSERVER_PROTOCOL変数を使用して応答の適切な形式を決定する必要があります。特定のプロトコル仕様によって義務付けられている可能性があるように、要求内の一般的またはプロトコル固有のメタ変数を考慮に入れる必要があります。
         </p>
       </div>
     </div>
@@ -2915,7 +2890,7 @@ The script MUST check the REQUEST_METHOD variable when processing the request an
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-スクリプトは、要求を処理してその応答を準備するときにrequest_method変数をチェックする必要があります。
+スクリプトは、要求を処理してその応答を準備するときにREQUEST_METHOD変数をチェックする必要があります。
         </p>
       </div>
     </div>
@@ -2952,7 +2927,7 @@ The response comprises a message-header and a message-body, separated by a blank
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-応答は、メッセージヘッダとメッセージ本文を含む、空白行で区切られています。message-headerには、1つ以上のヘッダーフィールドが含まれています。本体はヌルかもしれません。
+応答は、メッセージヘッダとメッセージ本文を含む、空白行で区切られています。message-headerには、1つ以上のヘッダーフィールドが含まれています。本体はNULLかもしれません。
         </p>
       </div>
     </div>
@@ -2977,14 +2952,9 @@ The script MUST return one of either a document response, a local redirect respo
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 CGI-Response = document-response | local-redir-response | client-redir-response | client-redirdoc-response
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-CGI-Response = Document-Response.
         </p>
       </div>
     </div>
@@ -3014,14 +2984,9 @@ CGIスクリプトは文書応答内のユーザーにドキュメントを返�
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 document-response = Content-Type [ Status ] *other-field NL response-body
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-document-response = content-type [status] *その他フィールドNLレスポンスボディ
         </p>
       </div>
     </div>
@@ -3058,7 +3023,7 @@ The CGI script can return a URI path and query-string (&#39;local-pathquery&#39;
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-CGIスクリプトは、ロケーションヘッダーフィールドのローカルリソースのURIパスとクエリ文字列（ &#39;local-pathquery&#39;）を返すことができます。これは、指定されたパスを使用して要求を再処理する必要があることをサーバーに示しています。
+CGIスクリプトは、ロケーションヘッダーフィールドのローカルリソースのURIパスとクエリ文字列（&#39;local-pathquery&#39;）を返すことができます。これは、指定されたパスを使用して要求を再処理する必要があることをサーバーに示しています。
         </p>
       </div>
     </div>
@@ -3116,14 +3081,9 @@ CGIスクリプトは、指定されたURIを使用して要求を再処理す�
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 client-redir-response = client-Location *extension-field NL
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-client-redir-response = client-location *拡張フィールドNL
         </p>
       </div>
     </div>
@@ -3165,14 +3125,9 @@ CGIスクリプトは、指定されたURIを使用してリクエストを再�
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 client-redirdoc-response = client-Location Status Content-Type *other-field NL response-body
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-クライアントredirdoc-response = client-location status content-type *その他フィールドNLレスポンスボディ
         </p>
       </div>
     </div>
@@ -3184,7 +3139,7 @@ The Status header field MUST be supplied and MUST contain a status value of 302 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-ステータスヘッダーフィールドは指定されている必要があり、ステータス値302 &#39;が含まれている必要があります。また、拡張コード、つまりクライアントリダイレクトを意味するもう1つの有効なステータスコードを含めることができます。サーバーは、クライアントへの応答が応答プロトコルのバージョンに準拠していることを確認するために、スクリプトの出力を適切な変更を加える必要があります。
+ステータスヘッダーフィールドは指定されている必要があり、ステータス値302 &#39;Found&#39;が含まれている必要があります。また、拡張コード、つまりクライアントリダイレクトを意味するもう1つの有効なステータスコードを含めることができます。サーバーは、クライアントへの応答が応答プロトコルのバージョンに準拠していることを確認するために、スクリプトの出力を適切な変更を加える必要があります。
         </p>
       </div>
     </div>
@@ -3237,7 +3192,7 @@ The field-name is not case sensitive. A NULL field value is equivalent to a fiel
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-フィールド名は大文字と小文字を区別しません。NULLフィールド値は、送信されていないフィールドと同じです。CGI応答内の各ヘッダーフィールドは、1行に指定する必要があります。CGI / 1.1は継続行をサポートしません。「：」とフィールド値（フィールド名と &#34;：&#34;の間ではなく、フィールド値の間ではありません）、およびフィールド値のトークン間での空白が許可されています。
+フィールド名は大文字と小文字を区別しません。NULLフィールド値は、送信されていないフィールドと同じです。CGI応答内の各ヘッダーフィールドは、1行に指定する必要があります。CGI/1.1は継続行をサポートしません。「：」とフィールド値（フィールド名と &#34;:&#34;の間ではなく、フィールド値の間ではありません）、およびフィールド値のトークン間での空白が許可されています。
         </p>
       </div>
     </div>
@@ -3249,7 +3204,7 @@ The field-name is not case sensitive. A NULL field value is equivalent to a fiel
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-6.3.1. コンテンツタイプ
+6.3.1. Content-Type
         </h5>
       </div>
 
@@ -3267,14 +3222,9 @@ Content-Type Responseフィールドは、エンティティ本体のインタ�
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
+      <div class="col-sm-12 col-md-12">
+        <pre class="text text-monospace">
 Content-Type = &#34;Content-Type:&#34; media-type NL
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-6">
-        <p class="text indent-6">
-content-type = &#34;content-type：&#34;メディアタイプNL
         </p>
       </div>
     </div>
@@ -3298,7 +3248,7 @@ Unless it is otherwise system-defined, the default charset assumed by the client
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-それ以外の場合を定義しない限り、プロトコルがHTTPおよびUS-ASCIIの場合は、クライアントに想定されているデフォルトの文字セットがISO-8859-1です。したがって、スクリプトにはCharsetパラメータを含める必要があります。この問題の説明については、http / 1.1仕様書[4]のセクション3.4.1を参照してください。
+それ以外の場合を定義しない限り、プロトコルがHTTPおよびUS-ASCIIの場合は、クライアントに想定されているデフォルトの文字セットがISO-8859-1です。したがって、スクリプトにはCharsetパラメータを含める必要があります。この問題の説明については、HTTP/1.1仕様書[4]のセクション3.4.1を参照してください。
         </p>
       </div>
     </div>
@@ -3310,7 +3260,7 @@ Unless it is otherwise system-defined, the default charset assumed by the client
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-6.3.2. ロケーション
+6.3.2. Location
         </h5>
       </div>
 
@@ -3323,7 +3273,7 @@ The Location header field is used to specify to the server that the script is re
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-ロケーションヘッダーフィールドは、スクリプトが実際の文書ではなく文書への参照を返しているサーバーに指定するために使用されます（セクション6.2.3と6.2.4を参照）。それは絶対的なURI（任意選択でフラグメント識別子を持つ）であり、クライアントが参照されている文書を取得すること、またはローカルURIパス（オプションでクエリ文字列を含む）が参照され、サーバーが参照された文書を取得して戻ることを示すことを示しています。応答としてクライアントに。
+Locationヘッダーフィールドは、スクリプトが実際の文書ではなく文書への参照を返しているサーバーに指定するために使用されます（セクション6.2.3と6.2.4を参照）。それは絶対的なURI（任意選択でフラグメント識別子を持つ）であり、クライアントが参照されている文書を取得すること、またはローカルURIパス（オプションでクエリ文字列を含む）が参照され、サーバーが参照された文書を取得して戻ることを示すことを示しています。応答としてクライアントに。
         </p>
       </div>
     </div>
@@ -3353,7 +3303,7 @@ The syntax of an absoluteURI is incorporated into this document from that specif
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-AbsoluteURIの構文は、RFC 2396 [2]とRFC 2732 [7]で指定されたものからこの文書に組み込まれています。有効なAxtriputeURIは常にスキームの名前で始まり、続いて &#34;：&#34;;スキーム名は文字で始まり、英数字、 &#34;&#34;、 &#34; - &#34;または &#34;。&#34;。 &#34;。&#34;。ローカルのURIパスとクエリは絶対パスでなければならず、相対パスまたはNULLではなく、したがって「/」で始める必要があります。
+AbsoluteURIの構文は、RFC 2396 [2]とRFC 2732 [7]で指定されたものからこの文書に組み込まれています。有効なAxtriputeURIは常にスキームの名前で始まり、続いて &#34;:&#34;;スキーム名は文字で始まり、英数字、 &#34;+&#34;、 &#34;-&#34;または &#34;.&#34;。ローカルのURIパスとクエリは絶対パスでなければならず、相対パスまたはNULLではなく、したがって&#34;/&#34;で始める必要があります。
         </p>
       </div>
     </div>
@@ -3413,7 +3363,7 @@ The Status header field contains a 3-digit integer result code that indicates th
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-0">
-ステータスコード200 &#39;OK&#39;は成功を示し、文書応答に想定されているデフォルト値です。ステータスコード302 &#39;found&#39;は、ロケーションヘッダーフィールドと応答メッセージボディで使用されます。ステータスコード400「不正な要求」は、欠落content_typeなどの未知の要求形式に使用できます。ステータスコード501 &#39;実装されていない&#39;は、サポートされていない要求_methodを受信した場合、スクリプトによって返される可能性があります。
+ステータスコード200 &#39;OK&#39;は成功を示し、文書応答に想定されているデフォルト値です。ステータスコード302 &#39;Found&#39;は、ロケーションヘッダーフィールドと応答メッセージボディで使用されます。ステータスコード400 &#39;Bad Request&#39;は、欠落CONTENT_TYPEなどの未知の要求形式に使用できます。ステータスコード501 &#39;Not Implemented&#39;は、サポートされていない要求_methodを受信した場合、スクリプトによって返される可能性があります。
         </p>
       </div>
     </div>
@@ -3425,7 +3375,7 @@ Other valid status codes are listed in section 6.1.1 of the HTTP specifications 
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-その他の有効なステータスコードは、HTTP仕様[1]、[4]、およびIANA HTTPステータスコードレジストリ[8]のセクション6.1.1にリストされており、上記のものに加えて、またはその代わりに使用できます。スクリプトは、HTTP / 1.1ステータスコードを使用する前にServer_Protocolの値を確認する必要があります。スクリプトは、エラー405 &#39;メソッドが許可されていません。メソッドを使用して作成されたHTTP / 1.1の要求はサポートされていません。
+その他の有効なステータスコードは、HTTP仕様[1]、[4]、およびIANA HTTPステータスコードレジストリ[8]のセクション6.1.1にリストされており、上記のものに加えて、またはその代わりに使用できます。スクリプトは、HTTP/1.1ステータスコードを使用する前にSERVER_PROTOCOLの値を確認する必要があります。スクリプトは、エラー405 &#39;Method Not Allowed&#39;で拒否される場合があります。メソッドを使用して作成されたHTTP/1.1の要求はサポートされていません。
         </p>
       </div>
     </div>
@@ -3449,7 +3399,7 @@ The reason-phrase is a textual description of the error to be returned to the cl
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-reason-句は、人間の消費のためにクライアントに返されるエラーのテキスト記述です。
+reason-phraseは、人間の消費のためにクライアントに返されるエラーのテキスト記述です。
         </p>
       </div>
     </div>
@@ -3474,7 +3424,7 @@ The script MAY return any other header fields that relate to the response messag
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-このスクリプトは、server_protocolの指定によって定義された応答メッセージに関連する他のヘッダーフィールド（http / 1.0 [1]またはhttp / 1.1 [4]）を返すことができます。これらが異なる場合、サーバーはヘッダーデータをCGIヘッダー構文からHTTPヘッダー構文に変換する必要があります。たとえば、CGIスクリプトで使用される改行の文字列（UNIXのUS-ASCII LFなど）は、HTTP（US-ASCII CRに続くLF）で使用されているものと同じではない可能性があります。
+このスクリプトは、SERVER_PROTOCOLの指定によって定義された応答メッセージに関連する他のヘッダーフィールド（HTTP/1.0 [1]またはHTTP/1.1 [4]）を返すことができます。これらが異なる場合、サーバーはヘッダーデータをCGIヘッダー構文からHTTPヘッダー構文に変換する必要があります。たとえば、CGIスクリプトで使用される改行の文字列（UNIXのUS-ASCII LFなど）は、HTTP（US-ASCII CRに続くLF）で使用されているものと同じではない可能性があります。
         </p>
       </div>
     </div>
@@ -3569,7 +3519,7 @@ The response message-body is an attached document to be returned to the client b
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-7.1. アミガドス
+7.1. AmigaDOS
         </h5>
       </div>
 
@@ -3618,7 +3568,7 @@ Character set The US-ASCII character set [9] is used for the definition of meta-
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-7.2. un un
+7.2. UNIX
         </h5>
       </div>
 
@@ -3679,7 +3629,7 @@ Character set The US-ASCII character set [9], excluding NUL, is used for the def
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-文字セットNULを除くUS-ASCII文字セット[9]は、メタ変数、ヘッダーフィールド、およびCHAR値の定義に使用されます。テキスト値ISO-8859-1を使用します。path_translated値は、NUL以外の8ビットバイトを含めることができます。改行（NL）シーケンスはLFです。サーバーはまた、改行としてCR LFを受け入れる必要があります。
+文字セットNULを除くUS-ASCII文字セット[9]は、メタ変数、ヘッダーフィールド、およびCHAR値の定義に使用されます。テキスト値ISO-8859-1を使用します。PATH_TRANSLATED値は、NUL以外の8ビットバイトを含めることができます。改行（NL）シーケンスはLFです。サーバーはまた、改行としてCR LFを受け入れる必要があります。
         </p>
       </div>
     </div>
@@ -3691,7 +3641,7 @@ Character set The US-ASCII character set [9], excluding NUL, is used for the def
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-7.3. EBCDIC / POSIX
+7.3. EBCDIC/POSIX
         </h5>
       </div>
 
@@ -3863,7 +3813,7 @@ If the script does not intend processing the PATH_INFO data, then it should reje
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-スクリプトがPATH_INFOデータの処理をインテンドしない場合、path_infoがnullではない場合は404で要求を拒否します。
+スクリプトがPATH_INFOデータの処理をインテンドしない場合、PATH_INFOがNULLではない場合は404で要求を拒否します。
         </p>
       </div>
     </div>
@@ -3875,7 +3825,7 @@ If the output of a form is being processed, check that CONTENT_TYPE is &#34;appl
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-フォームの出力が処理されている場合は、content_typeが &#34;application / x-www-orf-urlencoded&#34;または &#34;multipart / form-data&#34; [16]であることを確認してください。content_typeが空白の場合、スクリプトはプロトコルによってサポートされている415 &#39;サポートされていないメディアタイプのエラーで要求を拒否できます。
+フォームの出力が処理されている場合は、CONTENT_TYPEが &#34;application/x-www-orf-urlencoded&#34;または &#34;multipart/form-data&#34; [16]であることを確認してください。CONTENT_TYPEが空白の場合、スクリプトはプロトコルによってサポートされている415 &#39;サポートされていないメディアタイプのエラーで要求を拒否できます。
         </p>
       </div>
     </div>
@@ -3887,7 +3837,7 @@ When parsing PATH_INFO, PATH_TRANSLATED or SCRIPT_NAME the script should be care
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-path_infoを解析するとき、path_translatedまたはscript_nameスクリプトは、Void Pathセグメント（ &#34;//&#34;）と特殊なパスセグメント（ &#34;。&#34;と &#34;。&#34;）に注意してください。OSシステムコールで使用する前にパスから削除する必要があります。また、リクエストは404 &#39;found&#39;で拒否されるべきです。
+PATH_INFOを解析するとき、PATH_TRANSLATEDまたはSCRIPT_NAMEスクリプトは、Void Pathセグメント（&#34;//&#34;）と特殊なパスセグメント（&#34;。&#34;と &#34;。&#34;）に注意してください。OSシステムコールで使用する前にパスから削除する必要があります。また、リクエストは404 &#39;Not Found&#39;で拒否されるべきです。
         </p>
       </div>
     </div>
@@ -3936,7 +3886,7 @@ Script authors should be aware that the REMOTE_ADDR and REMOTE_HOST meta-variabl
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-9.1. 安全な方法
+9.1. 安全なメソッド
         </h5>
       </div>
 


### PR DESCRIPTION
機械翻訳による意味がとりにくい部分の翻訳と仕様に関わる大文字小文字違いを最低限修正しました。
また、一行のABNFが本文として翻訳されていたので、翻訳しないようにしました。

網羅的には確認していないので、おそらく修正漏れがあります。