### PR TITLE
feat: Add dark mode

### DIFF
--- a/html/index.js
+++ b/html/index.js
@@ -53,4 +53,24 @@ document.addEventListener('DOMContentLoaded', function () {
     httpRequest.send();
   }
 
+  // add theme toggle button to page
+  const themeToggleButton = document.createElement('button');
+  const buttonToOriginalContainer = document.getElementsByClassName('jump-to-original-rfc-container')[0];
+  const buttonToOriginal = buttonToOriginalContainer.childNodes[0];
+  let darkMode = false;
+  themeToggleButton.innerHTML = 'Dark';
+  themeToggleButton.classList.add('btn', 'btn-light', 'btn-sm');
+
+  themeToggleButton.addEventListener('click', function () {
+    if (darkMode) {
+      themeToggleButton.innerHTML = 'Dark'
+      darkMode = false;
+    } else {
+      themeToggleButton.innerHTML = 'Light'
+      darkMode = true;
+    }
+    document.body.classList.toggle('dark-theme');
+  });
+
+  buttonToOriginalContainer.insertBefore(themeToggleButton, buttonToOriginal);
 });

--- a/html/master.css
+++ b/html/master.css
@@ -63,3 +63,50 @@ button .jump-to-original-rfc:hover {
   color: #0056b3;
   text-decoration: underline;
 }
+
+/* Dark Theme */
+
+:root {
+  --color-bg-dark: #121212;
+  --color-text-dark: #b2b2b2;
+}
+
+body.dark-theme {
+  background-color: var(--color-bg-dark);
+}
+
+.dark-theme h1, .dark-theme h2, .dark-theme h3, .dark-theme h4, .dark-theme h5, .dark-theme p, .dark-theme pre {
+  color: var(--color-text-dark);
+}
+
+.dark-theme nav {
+  background-color: #19191c !important;
+}
+
+.dark-theme nav a, .dark-theme nav span,
+.dark-theme .container a, .dark-theme .container span {
+  color: var(--color-text-dark) !important;
+}
+
+.dark-theme .alert {
+  background-color: #151718 !important;
+  border-color: #373d3e !important;
+}
+
+.dark-theme .alert * {
+  color: #c2cfdb !important;
+}
+
+.dark-theme .alert a {
+  color: #3c7ee3 !important;
+}
+
+.dark-theme .jump-to-original-rfc-container button {
+  background-color: var(--color-bg-dark);
+  color: var(--color-text-dark);
+}
+
+.dark-theme .list-group-item {
+  background-color: var(--color-bg-dark);
+  border-color: rgba(255, 255, 255, 0.125);
+}

--- a/html/master.css
+++ b/html/master.css
@@ -88,9 +88,14 @@ body.dark-theme {
   color: var(--color-text-dark) !important;
 }
 
-.dark-theme .alert {
+.dark-theme .alert-info {
   background-color: #151718 !important;
   border-color: #373d3e !important;
+}
+
+.dark-theme .alert-danger {
+  background-color: #300401 !important;
+  border-color: #442b2b !important;
 }
 
 .dark-theme .alert * {


### PR DESCRIPTION
- ダークテーマに切り替えるボタンを追加しました
- GitHub の dark theme が青み系なのでスクリーンショットを見ると茶色っぽく見えますがベースは `#121212` で、眩しすぎないようにしつつ文字とのコントラスト比は 8:1 くらいにしてあります

![index](https://user-images.githubusercontent.com/12470841/149627316-59912c85-b2ed-461d-9ef0-37ce48980c63.png)
![page](https://user-images.githubusercontent.com/12470841/149627313-c56cea0a-d952-4d95-b52c-7a4be9a0d39b.png)
