### PR TITLE
RFC5646 Appendix Aのlanguage tagの例の修正

### DIFF
--- a/html/rfc5646.html
+++ b/html/rfc5646.html
@@ -52,7 +52,7 @@
         </span><br>
         <span class="title_ja">
           タイトル : <strong>RFC 5646 - 言語を識別するためのタグ</strong></span><br>
-        <span class="updated_by">翻訳編集 : 自動生成</span><span id="rfc_status"></span><span id="rfc_wg"></span><br>
+        <span class="updated_by">翻訳編集 : 自動生成＆有志による翻訳・編集</span><span id="rfc_status"></span><span id="rfc_wg"></span><br>
       </div>
       <div id="rfc_alert" class="hidden" role="alert">
         <div class="alert alert-danger">
@@ -8290,7 +8290,7 @@ de (German)
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-6">
-で （げｒまん）
+de（ドイツ語）
         </p>
       </div>
     </div>
@@ -8314,7 +8314,7 @@ ja (Japanese)
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-6">
-はい（日本語）
+ja（日本語）
         </p>
       </div>
     </div>


### PR DESCRIPTION
rfc-translater 大変お世話になっております。
公開いただきありがとうございます。

RFC5646のlanguage tagの例を見ていたところ自動翻訳で修正できる点に気づきPRをお送りいたします。
https://github.com/tex2e/rfc-translater#%E7%BF%BB%E8%A8%B3%E4%BF%AE%E6%AD%A3%E8%80%85 を参照しましたが、不備がありましたらお知らせください