### PR TITLE
Update rfc4251-trans.json

### DIFF
--- a/data/4000/rfc4251-trans.json
+++ b/data/4000/rfc4251-trans.json
@@ -746,8 +746,8 @@
     },
     {
       "indent": 9,
-      "text": "read from user encrypt null packet encrypt data packet",
-      "ja": "ユーザーからの読み取りnullパケットの暗号化データパケットの暗号化"
+      "text": "read from user\nencrypt null packet\nencrypt data packet",
+      "ja": "ユーザーからの読み取り\nnullパケットの暗号化\nデータパケットの暗号化"
     },
     {
       "indent": 0,


### PR DESCRIPTION
add \n in the list of statements.

In the original RFC https://datatracker.ietf.org/doc/html/rfc4251#section-9.3.1 , elements of the list are splited by \n.

Original:
>  read from user
>  encrypt null packet
>  encrypt data packet

Current repository:
> read from user encrypt null packet encrypt data packet