### PR TITLE
Fix titile of section 3.2

### DIFF
--- a/html/rfc8402.html
+++ b/html/rfc8402.html
@@ -48,7 +48,7 @@
         </span><br>
         <span class="title_ja">
           タイトル : <strong>RFC 8402 - セグメントルーティングアーキテクチャ</strong></span><br>
-        <span class="updated_by">翻訳編集 : 自動生成</span><span id="rfc_status"></span><span id="rfc_wg"></span><br>
+        <span class="updated_by">翻訳編集 : 自動生成＆有志による翻訳・編集</span><span id="rfc_status"></span><span id="rfc_wg"></span><br>
       </div>
       <div id="rfc_alert" class="hidden" role="alert">
         <div class="alert alert-danger">
@@ -1289,7 +1289,7 @@ Nodes that do not support a given algorithm may still have a FIB entry covering 
       </div>
       <div class="col-sm-12 col-md-6">
         <h5 class="text mt-2">
-3.2. いＧＰーので せｇめんｔ （のでーしＤ）
+3.2. IGP-Nodeセグメント（Node-SID）
         </h5>
       </div>
     </div>


### PR DESCRIPTION
いつもお世話になっております。
RFC8402のセクションタイトルが変になっていたので修正してみました。
ご確認いただけると幸いです。よろしくお願いいたします。

変更点
- section 3.2のタイトルの修正
```
いＧＰーので せｇめんｔ （のでーしＤ） ->  IGP-Nodeセグメント（Node-SID)
```