### PR TITLE
Fix boundary delimiter defintion in japanese

### DIFF
--- a/html/rfc7578.html
+++ b/html/rfc7578.html
@@ -48,7 +48,7 @@
         </span><br>
         <span class="title_ja">
           タイトル : <strong>RFC 7578 - フォームから値を返す：multipart / form-data</strong></span><br>
-        <span class="updated_by">翻訳編集 : 自動生成</span><span id="rfc_status"></span><span id="rfc_wg"></span><br>
+        <span class="updated_by">翻訳編集 : 自動生成＆有志による翻訳・編集</span><span id="rfc_status"></span><span id="rfc_wg"></span><br>
       </div>
       <div id="rfc_alert" class="hidden" role="alert">
         <div class="alert alert-danger">

--- a/html/rfc7578.html
+++ b/html/rfc7578.html
@@ -443,7 +443,7 @@ As with other multipart types, the parts are delimited with a boundary delimiter
       </div>
       <div class="col-sm-12 col-md-6">
         <p class="text indent-3">
-他のマルチパートタイプと同様に、パートはCRLF、「-」、および「boundary」パラメーターの値を使用して構築された境界区切り文字で区切られます。境界は、multipart / form-dataタイプへの「boundary」パラメーターとして提供されます。 [RFC2046]のセクション5.1に記載されているように、境界区切り文字はカプセル化された部分の内部に表示してはならず、「境界」パラメーター値をContent-Typeヘッダーフィールドで引用符で囲む必要があることがよくあります。
+他のマルチパートタイプと同様に、パートはCRLF、「--」、および「boundary」パラメーターの値を使用して構築された境界区切り文字で区切られます。境界は、multipart / form-dataタイプへの「boundary」パラメーターとして提供されます。 [RFC2046]のセクション5.1に記載されているように、境界区切り文字はカプセル化された部分の内部に表示してはならず、「境界」パラメーター値をContent-Typeヘッダーフィールドで引用符で囲む必要があることがよくあります。
         </p>
       </div>
     </div>


### PR DESCRIPTION
## 変更点
- RFC7578 「4.1. multipart / form-dataの「境界」パラメーター」の１文目で、boundaryを構成する文字列の説明に誤訳があったため修正
- RFC7578の翻訳文に、有志による翻訳・編集があった旨を追加
```
old:（前略）パートはCRLF、「-」、および「boundary」パラメーターの値を（後略）
new:（前略）パートはCRLF、「--」、および「boundary」パラメーターの値を（後略）