### PR TITLE
fix: remove ../ from requirements.txt COPY path in Containerfile

### DIFF
--- a/scraping-app/Containerfile
+++ b/scraping-app/Containerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/app/
 RUN adduser --disabled-login mako && chown -R mako /opt/app/
 USER mako
 
-COPY ../requirements.txt /opt/app/
+COPY requirements.txt /opt/app/
 RUN pip install -r /opt/app/requirements.txt
 COPY exec.py /opt/app/
 


### PR DESCRIPTION
https://github.com/tex2e/rfc-translater/commit/e1405ee7a578be0e8e637e37d62c576e1872475d で `requirements.txt` を `scraping-app/` に移動したにも拘わらず `scraping-app/Containerfile` は以前の場所を指しているように見受けられます。

owner さんの環境でうまく動作しているようであればすみません。